### PR TITLE
fix: CSS-related FluentUI bugs

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -151,72 +151,65 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     <ContentLink deps={props.deps} reference={props.guidance} iconName="info" />
                 </h1>
                 {description}
-                <ThemeFamilyCustomizer
-                    themeFamily={'default'}
-                    userConfigurationStoreData={props.userConfigurationStoreData}
-                >
-                    <Toggle
-                        onClick={clickHandler}
-                        id="tab-stops-visual-helper"
-                        label="Visual helper"
-                        checked={scanData.enabled}
-                        className={styles.visualHelperToggle}
-                    />
-                </ThemeFamilyCustomizer>
+                <Toggle
+                    onClick={clickHandler}
+                    id="tab-stops-visual-helper"
+                    label="Visual helper"
+                    checked={scanData.enabled}
+                    className={styles.visualHelperToggle}
+                />
                 <CollapsibleComponent
                     header={<h2 className={styles.requirementHowToTestHeader}>How to test</h2>}
                     content={howToTest}
                     contentClassName={requirementInstructionStyles.requirementInstructions}
                 />
                 <h2 className={styles.requirementTableTitle}>Record your results</h2>
-                <TabStopsRequirementsTable
-                    deps={props.deps}
-                    requirementState={requirementState}
-                    featureFlagStoreData={props.featureFlagStoreData}
-                />
-                <TabStopsFailedInstanceSection
-                    deps={props.deps}
-                    tabStopRequirementState={
-                        props.visualizationScanResultData.tabStops.requirements
-                    }
-                    alwaysRenderSection={false}
-                    sectionHeadingLevel={2}
-                    featureFlagStoreData={props.featureFlagStoreData}
-                />
-                <TabStopsFailedInstancePanel
-                    deps={props.deps}
-                    failureInstanceState={props.tabStopsViewStoreData.failureInstanceState}
-                    requirementState={requirementState}
-                />
-                <FlaggedComponent
-                    featureFlag={FeatureFlags.tabStopsAutomation}
-                    featureFlagStoreData={props.featureFlagStoreData}
-                    enableJSXElement={
-                        <FocusComponent deps={props.deps} tabbingEnabled={scanData.enabled} />
-                    }
-                />
-                <FlaggedComponent
-                    featureFlag={FeatureFlags.tabStopsAutomation}
-                    featureFlagStoreData={props.featureFlagStoreData}
-                    enableJSXElement={
-                        <AutoDetectedFailuresDialog
-                            visualizationScanResultData={props.visualizationScanResultData}
-                        />
-                    }
-                />
+                <ThemeFamilyCustomizer
+                    themeFamily={'fast-pass'}
+                    userConfigurationStoreData={props.userConfigurationStoreData}
+                >
+                    <TabStopsRequirementsTable
+                        deps={props.deps}
+                        requirementState={requirementState}
+                        featureFlagStoreData={props.featureFlagStoreData}
+                    />
+                    <TabStopsFailedInstanceSection
+                        deps={props.deps}
+                        tabStopRequirementState={
+                            props.visualizationScanResultData.tabStops.requirements
+                        }
+                        alwaysRenderSection={false}
+                        sectionHeadingLevel={2}
+                        featureFlagStoreData={props.featureFlagStoreData}
+                    />
+                    <TabStopsFailedInstancePanel
+                        deps={props.deps}
+                        failureInstanceState={props.tabStopsViewStoreData.failureInstanceState}
+                        requirementState={requirementState}
+                    />
+                    <FlaggedComponent
+                        featureFlag={FeatureFlags.tabStopsAutomation}
+                        featureFlagStoreData={props.featureFlagStoreData}
+                        enableJSXElement={
+                            <FocusComponent deps={props.deps} tabbingEnabled={scanData.enabled} />
+                        }
+                    />
+                    <FlaggedComponent
+                        featureFlag={FeatureFlags.tabStopsAutomation}
+                        featureFlagStoreData={props.featureFlagStoreData}
+                        enableJSXElement={
+                            <AutoDetectedFailuresDialog
+                                visualizationScanResultData={props.visualizationScanResultData}
+                            />
+                        }
+                    />
+                </ThemeFamilyCustomizer>
             </>
         );
 
         return (
             <div className={styles.tabStopsTestViewContainer}>
-                <div className={styles.tabStopsTestView}>
-                    <ThemeFamilyCustomizer
-                        themeFamily={'fast-pass'}
-                        userConfigurationStoreData={props.userConfigurationStoreData}
-                    >
-                        {tabStopsTestViewContents}
-                    </ThemeFamilyCustomizer>
-                </div>
+                <div className={styles.tabStopsTestView}>{tabStopsTestViewContents}</div>
             </div>
         );
     },

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -48,7 +48,6 @@
         .ms-Nav-compositeLink {
             a,
             button {
-                border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
                 border-top: 0px;
                 border-bottom: 0px;
             }
@@ -59,8 +58,6 @@
                 a,
                 button {
                     background-color: $communication-tint-40;
-                    border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
-                        $communication-primary;
                     .ms-Button-label,
                     .overview-percent {
                         color: $highlighted-text;
@@ -71,7 +68,8 @@
                 }
                 a::after,
                 button::after {
-                    border-left: 0px;
+                    border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
+                        $communication-primary;
                 }
                 .ms-Button-label {
                     color: $always-black;

--- a/src/DetailsView/components/requirement-view.scss
+++ b/src/DetailsView/components/requirement-view.scss
@@ -11,6 +11,11 @@
     height: 100%;
     justify-content: space-between;
 
+    .next-requirement-button-container {
+        display: flex;
+        flex-direction: column;
+    }
+
     .next-requirement-button {
         align-self: flex-end;
         margin-bottom: 1vh;

--- a/src/DetailsView/components/requirement-view.tsx
+++ b/src/DetailsView/components/requirement-view.tsx
@@ -143,12 +143,14 @@ export class RequirementView extends React.Component<RequirementViewProps> {
                         />
                     </div>
                 </div>
-                <NextRequirementButton
-                    deps={this.props.deps}
-                    nextRequirement={nextRequirement}
-                    currentTest={this.props.assessmentNavState.selectedTestType}
-                    className={styles.nextRequirementButton}
-                />
+                <div className={styles.nextRequirementButtonContainer}>
+                    <NextRequirementButton
+                        deps={this.props.deps}
+                        nextRequirement={nextRequirement}
+                        currentTest={this.props.assessmentNavState.selectedTestType}
+                        className={styles.nextRequirementButton}
+                    />
+                </div>
             </div>
         );
     }

--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -13,7 +13,7 @@ button.insights-command-button {
             color: $disabled-text;
         }
     }
-    &:active {
+    &:active:not(:disabled) {
         .command-bar-button-icon {
             color: $primary-text;
         }

--- a/src/common/components/new-tab-link-with-tooltip.scss
+++ b/src/common/components/new-tab-link-with-tooltip.scss
@@ -13,3 +13,12 @@
     display: inline-block;
     min-width: 0;
 }
+
+.insights-link {
+    &:hover {
+        text-decoration: none;
+    }
+    i {
+        display: inline;
+    }
+}

--- a/src/common/components/new-tab-link-with-tooltip.scss
+++ b/src/common/components/new-tab-link-with-tooltip.scss
@@ -15,10 +15,10 @@
 }
 
 .insights-link {
-    &:hover {
-        text-decoration: none;
-    }
-    i {
-        display: inline;
+    display: flex;
+
+    &:hover,
+    &:active {
+        text-decoration: none !important;
     }
 }

--- a/src/common/components/new-tab-link-with-tooltip.tsx
+++ b/src/common/components/new-tab-link-with-tooltip.tsx
@@ -23,7 +23,7 @@ export const NewTabLinkWithTooltip = NamedFC<NewTabLinkWithTooltipProps>(
         };
         return (
             <TooltipHost content={tooltipContent} styles={hostStyles} calloutProps={calloutProps}>
-                <NewTabLink {...linkProps} />
+                <NewTabLink className={styles.insightsLink} {...linkProps} />
             </TooltipHost>
         );
     },

--- a/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Button, css, Icon } from '@fluentui/react';
+import { DefaultButton, css, Icon } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
@@ -24,30 +24,30 @@ export const VirtualKeyboardButtons = NamedFC<VirtualKeyboardButtonsProps>(
     props => {
         const getArrowButton = (text: string, onClick: () => void, className?: string) => {
             return (
-                <Button
+                <DefaultButton
                     onClick={onClick}
                     className={styles.button}
                     data-automation-id={buildKeyboardButtonAutomationId(text)}
                     primary
                 >
                     <span className={styles.innerButtonContainer}>
-                        <Icon iconName="upArrow" className={className} />
+                        <Icon iconName="Up" className={className} />
                         {text}
                     </span>
-                </Button>
+                </DefaultButton>
             );
         };
 
         const getLargeButton = (text: string, onClick: () => void, className?: string) => {
             return (
-                <Button
+                <DefaultButton
                     onClick={onClick}
                     className={css(className, styles.button)}
                     data-automation-id={buildKeyboardButtonAutomationId(text)}
                     primary
                 >
                     <span className={styles.innerButtonContainer}>{text}</span>
-                </Button>
+                </DefaultButton>
             );
         };
 

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -237,7 +237,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
             >
               <a
                 aria-label="Navigate to axe-core npm page"
-                class="ms-Link insights-link root-000"
+                class="ms-Link insights-link insights-link--{{CSS_MODULE_HASH}} root-000"
                 href="https://www.npmjs.com/package/axe-core"
                 target="_blank"
               >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -7,80 +7,75 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
   <div
     className="tabStopsTestView"
   >
-    <ThemeCustomizer
-      themeFamily="fast-pass"
-      userConfigurationStoreData="stub-user-configuration-store-data"
-    >
-      <React.Fragment>
-        <h1>
-          test title
-           Step 0 of 3 
-          <ContentLink
-            deps="stub-deps"
-            iconName="info"
-            reference="stub-guidance"
-          />
-        </h1>
-        <p>
-          <Emphasis>
-            Note: this test requires you to use a keyboard and to visually identify interactive elements.
-          </Emphasis>
-        </p>
-        <ThemeCustomizer
-          themeFamily="default"
-          userConfigurationStoreData="stub-user-configuration-store-data"
-        >
-          <StyledToggleBase
-            checked={true}
-            className="visualHelperToggle"
-            id="tab-stops-visual-helper"
-            label="Visual helper"
-            onClick={[Function]}
-          />
-        </ThemeCustomizer>
-        <CollapsibleComponent
-          content={
-            <ol>
-              <li>
-                Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
-              </li>
-              <li>
-                Use your keyboard to move input focus through all the interactive elements in the page:
-                <ol>
-                  <li>
-                    Use 
-                    <Term>
-                      Tab
-                    </Term>
-                     and
-                     
-                    <Term>
-                      Shift+Tab
-                    </Term>
-                     to navigate between standalone controls.
-                     
-                  </li>
-                  <li>
-                    Use the arrow keys to navigate between the focusable elements within a composite control.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          }
-          contentClassName="requirementInstructions"
-          header={
-            <h2
-              className="requirementHowToTestHeader"
-            >
-              How to test
-            </h2>
-          }
+    <React.Fragment>
+      <h1>
+        test title
+         Step 0 of 3 
+        <ContentLink
+          deps="stub-deps"
+          iconName="info"
+          reference="stub-guidance"
         />
-        <h2
-          className="requirementTableTitle"
-        >
-          Record your results
-        </h2>
+      </h1>
+      <p>
+        <Emphasis>
+          Note: this test requires you to use a keyboard and to visually identify interactive elements.
+        </Emphasis>
+      </p>
+      <StyledToggleBase
+        checked={true}
+        className="visualHelperToggle"
+        id="tab-stops-visual-helper"
+        label="Visual helper"
+        onClick={[Function]}
+      />
+      <CollapsibleComponent
+        content={
+          <ol>
+            <li>
+              Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
+            </li>
+            <li>
+              Use your keyboard to move input focus through all the interactive elements in the page:
+              <ol>
+                <li>
+                  Use 
+                  <Term>
+                    Tab
+                  </Term>
+                   and
+                   
+                  <Term>
+                    Shift+Tab
+                  </Term>
+                   to navigate between standalone controls.
+                   
+                </li>
+                <li>
+                  Use the arrow keys to navigate between the focusable elements within a composite control.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        }
+        contentClassName="requirementInstructions"
+        header={
+          <h2
+            className="requirementHowToTestHeader"
+          >
+            How to test
+          </h2>
+        }
+      />
+      <h2
+        className="requirementTableTitle"
+      >
+        Record your results
+      </h2>
+      <ThemeCustomizer
+        themeFamily="fast-pass"
+        userConfigurationStoreData="stub-user-configuration-store-data"
+      >
         <TabStopsRequirementsTable
           deps="stub-deps"
           featureFlagStoreData={Object {}}
@@ -122,8 +117,8 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
           featureFlag="tabStopsAutomation"
           featureFlagStoreData={Object {}}
         />
-      </React.Fragment>
-    </ThemeCustomizer>
+      </ThemeCustomizer>
+    </React.Fragment>
   </div>
 </div>
 `;
@@ -135,79 +130,74 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
   <div
     className="tabStopsTestView"
   >
-    <ThemeCustomizer
-      themeFamily="fast-pass"
-      userConfigurationStoreData="stub-user-configuration-store-data"
-    >
-      <React.Fragment>
-        <h1>
-          test title
-           Step 0 of 3 
-          <ContentLink
-            deps="stub-deps"
-            iconName="info"
-          />
-        </h1>
-        <p>
-          <Emphasis>
-            Note: this test requires you to use a keyboard and to visually identify interactive elements.
-          </Emphasis>
-        </p>
-        <ThemeCustomizer
-          themeFamily="default"
-          userConfigurationStoreData="stub-user-configuration-store-data"
-        >
-          <StyledToggleBase
-            checked={true}
-            className="visualHelperToggle"
-            id="tab-stops-visual-helper"
-            label="Visual helper"
-            onClick={[Function]}
-          />
-        </ThemeCustomizer>
-        <CollapsibleComponent
-          content={
-            <ol>
-              <li>
-                Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
-              </li>
-              <li>
-                Use your keyboard to move input focus through all the interactive elements in the page:
-                <ol>
-                  <li>
-                    Use 
-                    <Term>
-                      Tab
-                    </Term>
-                     and
-                     
-                    <Term>
-                      Shift+Tab
-                    </Term>
-                     to navigate between standalone controls.
-                     
-                  </li>
-                  <li>
-                    Use the arrow keys to navigate between the focusable elements within a composite control.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          }
-          contentClassName="requirementInstructions"
-          header={
-            <h2
-              className="requirementHowToTestHeader"
-            >
-              How to test
-            </h2>
-          }
+    <React.Fragment>
+      <h1>
+        test title
+         Step 0 of 3 
+        <ContentLink
+          deps="stub-deps"
+          iconName="info"
         />
-        <h2
-          className="requirementTableTitle"
-        >
-          Record your results
-        </h2>
+      </h1>
+      <p>
+        <Emphasis>
+          Note: this test requires you to use a keyboard and to visually identify interactive elements.
+        </Emphasis>
+      </p>
+      <StyledToggleBase
+        checked={true}
+        className="visualHelperToggle"
+        id="tab-stops-visual-helper"
+        label="Visual helper"
+        onClick={[Function]}
+      />
+      <CollapsibleComponent
+        content={
+          <ol>
+            <li>
+              Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
+            </li>
+            <li>
+              Use your keyboard to move input focus through all the interactive elements in the page:
+              <ol>
+                <li>
+                  Use 
+                  <Term>
+                    Tab
+                  </Term>
+                   and
+                   
+                  <Term>
+                    Shift+Tab
+                  </Term>
+                   to navigate between standalone controls.
+                   
+                </li>
+                <li>
+                  Use the arrow keys to navigate between the focusable elements within a composite control.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        }
+        contentClassName="requirementInstructions"
+        header={
+          <h2
+            className="requirementHowToTestHeader"
+          >
+            How to test
+          </h2>
+        }
+      />
+      <h2
+        className="requirementTableTitle"
+      >
+        Record your results
+      </h2>
+      <ThemeCustomizer
+        themeFamily="fast-pass"
+        userConfigurationStoreData="stub-user-configuration-store-data"
+      >
         <TabStopsRequirementsTable
           deps="stub-deps"
           featureFlagStoreData={Object {}}
@@ -249,8 +239,8 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
           featureFlag="tabStopsAutomation"
           featureFlagStoreData={Object {}}
         />
-      </React.Fragment>
-    </ThemeCustomizer>
+      </ThemeCustomizer>
+    </React.Fragment>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
@@ -85,24 +85,28 @@ exports[`RequirementViewTest renders with content from props 1`] = `
       />
     </div>
   </div>
-  <NextRequirementButton
-    className="nextRequirementButton"
-    currentTest={0}
-    deps={
-      Object {
-        "assessmentViewUpdateHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
-        "assessmentsProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+  <div
+    className="nextRequirementButtonContainer"
+  >
+    <NextRequirementButton
+      className="nextRequirementButton"
+      currentTest={0}
+      deps={
+        Object {
+          "assessmentViewUpdateHandler": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          },
+          "assessmentsProvider": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          },
+        }
       }
-    }
-    nextRequirement={
-      Object {
-        "key": "other-requirement-key",
+      nextRequirement={
+        Object {
+          "key": "other-requirement-key",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/__snapshots__/new-tab-link-with-tooltip.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/new-tab-link-with-tooltip.test.tsx.snap
@@ -18,6 +18,7 @@ exports[` handles children 1`] = `
   }
 >
   <NewTabLink
+    className="insightsLink"
     href="test"
   >
     link text
@@ -42,6 +43,7 @@ exports[` renders with null tooltip content 1`] = `
   }
 >
   <NewTabLink
+    className="insightsLink"
     href="test"
   />
 </StyledTooltipHostBase>
@@ -65,6 +67,7 @@ exports[` renders with tooltip content 1`] = `
   }
 >
   <NewTabLink
+    className="insightsLink"
     href="test"
   />
 </StyledTooltipHostBase>

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
 <div
   className="virtualKeyboardButtons"
 >
-  <Button
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Tab-button"
     onClick={[Function]}
@@ -15,8 +15,8 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
     >
       Tab
     </span>
-  </Button>
-  <Button
+  </CustomizedDefaultButton>
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Up-button"
     onClick={[Function]}
@@ -26,12 +26,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
       className="innerButtonContainer"
     >
       <Memo(Icon)
-        iconName="upArrow"
+        iconName="Up"
       />
       Up
     </span>
-  </Button>
-  <Button
+  </CustomizedDefaultButton>
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Left-button"
     onClick={[Function]}
@@ -42,12 +42,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
     >
       <Memo(Icon)
         className="left"
-        iconName="upArrow"
+        iconName="Up"
       />
       Left
     </span>
-  </Button>
-  <Button
+  </CustomizedDefaultButton>
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Down-button"
     onClick={[Function]}
@@ -58,12 +58,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
     >
       <Memo(Icon)
         className="down"
-        iconName="upArrow"
+        iconName="Up"
       />
       Down
     </span>
-  </Button>
-  <Button
+  </CustomizedDefaultButton>
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Right-button"
     onClick={[Function]}
@@ -74,12 +74,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
     >
       <Memo(Icon)
         className="right"
-        iconName="upArrow"
+        iconName="Up"
       />
       Right
     </span>
-  </Button>
-  <Button
+  </CustomizedDefaultButton>
+  <CustomizedDefaultButton
     className="button"
     data-automation-id="virtual-keyboard-Enter-button"
     onClick={[Function]}
@@ -90,7 +90,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
     >
       Enter
     </span>
-  </Button>
+  </CustomizedDefaultButton>
 </div>
 `;
 
@@ -98,7 +98,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
 <div
   className="virtualKeyboardButtons"
 >
-  <Button
+  <CustomizedDefaultButton
     className="rectangleButton button"
     data-automation-id="virtual-keyboard-Tab-button"
     onClick={[Function]}
@@ -109,11 +109,11 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
     >
       Tab
     </span>
-  </Button>
+  </CustomizedDefaultButton>
   <div
     className="arrowButtonsContainer"
   >
-    <Button
+    <CustomizedDefaultButton
       className="button"
       data-automation-id="virtual-keyboard-Up-button"
       onClick={[Function]}
@@ -123,15 +123,15 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
         className="innerButtonContainer"
       >
         <Memo(Icon)
-          iconName="upArrow"
+          iconName="Up"
         />
         Up
       </span>
-    </Button>
+    </CustomizedDefaultButton>
     <div
       className="bottomRowButtons"
     >
-      <Button
+      <CustomizedDefaultButton
         className="button"
         data-automation-id="virtual-keyboard-Left-button"
         onClick={[Function]}
@@ -142,12 +142,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
         >
           <Memo(Icon)
             className="left"
-            iconName="upArrow"
+            iconName="Up"
           />
           Left
         </span>
-      </Button>
-      <Button
+      </CustomizedDefaultButton>
+      <CustomizedDefaultButton
         className="button"
         data-automation-id="virtual-keyboard-Down-button"
         onClick={[Function]}
@@ -158,12 +158,12 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
         >
           <Memo(Icon)
             className="down"
-            iconName="upArrow"
+            iconName="Up"
           />
           Down
         </span>
-      </Button>
-      <Button
+      </CustomizedDefaultButton>
+      <CustomizedDefaultButton
         className="button"
         data-automation-id="virtual-keyboard-Right-button"
         onClick={[Function]}
@@ -174,14 +174,14 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
         >
           <Memo(Icon)
             className="right"
-            iconName="upArrow"
+            iconName="Up"
           />
           Right
         </span>
-      </Button>
+      </CustomizedDefaultButton>
     </div>
   </div>
-  <Button
+  <CustomizedDefaultButton
     className="rectangleButton button"
     data-automation-id="virtual-keyboard-Enter-button"
     onClick={[Function]}
@@ -192,6 +192,6 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
     >
       Enter
     </span>
-  </Button>
+  </CustomizedDefaultButton>
 </div>
 `;


### PR DESCRIPTION
This pull request merges into the `fluentuiV8-migration` branch and will introduce fixes for CSS-related bugs found during the accessibility pass.

## Details

### Fix double focus border on `i` button 

https://github.com/JGibson2019/accessibility-insights-web/commit/a9f545b64fc34cb83a5837845459a4f206e87847 sets the icon to `inline`. The children of `NewTableLinkWithTooltip` appear to be inline elements. However, this causes an underline on the icon on hover. This commit will also remove the text-decoration for `NewTableLinkWithTooltip` since the tooltip provides an indicator.

NOTE: @JGibson2019 is working on fixing the nesting order of this component within headings. It's possible that work will fix the double focus border since one of the problems is that the component is inheriting a larger line-height. We may end up reverting this commit or adjusting it.

Current | Proposed
----|----
![The i button has a double border when focused](https://user-images.githubusercontent.com/2180540/156371375-08e9e1ff-080c-4a9a-85f6-1ce21ae38a7b.png) | ![The i button has a single border when focused](https://user-images.githubusercontent.com/2180540/156371622-094b3193-e5e2-4fcb-96ca-1ab7eb2cba6e.png)



Alternatives I considered:

- The element inheriting the parent's (h1) line-height. We don't see this error on the FastPass Tab stops (i) button, because that h1 doesn't use the mixin and so it has a smaller line-height. We could set `lineHeight: 'normal';` on ContentLink to prevent the element from inheriting the line-height of its parent, but it's unclear if this condition should be true for all implementations.
- The tooltip container is `inline-block`, the `ContentLink` is inline, but its `i` element child is inline-block. This inline sandwich contributes to the double border. We could set the ContentLink to have `display: inline-block`, but this could cause unexpected results in different applications of this component.

### Prevent `NextRequirementButton`'s height from collapsing 

https://github.com/JGibson2019/accessibility-insights-web/commit/9052d1ee3dacd61546c35e604571eba9d3ae55ca wraps the `NextRequirementButton` in a parent div that uses flexbox. I found this to be the best solution since it prevents the button's height from collapsing and respected `margin-bottom` of the element.

Alternatives I considered:
- set `flex-shrink: 0` on the button to prevent the element from collapsing, however, due to several nested container's `height: 100%` it's difficult to add `margin-bottom` to the button.
- make adjustments to parent elements that set `height: 100%`, ideally this should be a min-height however there are nested elements that are setting `height: 100%`.

Current | Proposed
---|---
![The State changes button height is squashed](https://user-images.githubusercontent.com/2180540/156371754-28685a98-86c0-4a25-a671-222c14558f50.png) | ![The State changes button's height is proportional](https://user-images.githubusercontent.com/2180540/156371871-72d0c017-6460-430b-9481-da6752a13430.png)


### Prevent "Pass unmarked instances" button from changing when disabled 

https://github.com/JGibson2019/accessibility-insights-web/commit/fb89cb351e78c950ca8d47828f77be3258031466 adds CSS to prevent the icon from appearing active when attempting to click the disabled button.


Current | Proposed
---|---
![The checkmark is highlighted when the button is disabled](https://user-images.githubusercontent.com/2180540/156372152-2f62a256-d8ed-4a58-bf5f-59c68c2056c3.png) | ![The checkmark is the same color as the disabled button's text](https://user-images.githubusercontent.com/2180540/156372274-8a550b6b-c71b-47fc-a0e7-0df1ddd5e33b.png)


### Replace deprecate Button and fix icons in Unified

https://github.com/JGibson2019/accessibility-insights-web/commit/896e333949dc78b6424f9e1236cde641a32c931e replaces the deprecated `Button` component with `DefaultButton` and updates the icon name from `UpArrow` to `Up`.

Current | Proposed
---|---
![White boxes appear instead of arrow icons on the up, left, down, and right virtual keyboard buttons.](https://user-images.githubusercontent.com/2180540/156373566-792317e7-d58c-4f52-a8bf-595e670a70a2.png) | ![The correct arrow icons appears on the virtual keyboard buttons.](https://user-images.githubusercontent.com/2180540/156373816-73b1f46f-89bf-44b8-bc1a-358cc9e67fc3.png)



### Fix double focus border on left nav links

https://github.com/JGibson2019/accessibility-insights-web/commit/cb48a2fc4aea8133005f4493760c48f34b44ac11 removes `border-left` from the `a,button` elements and instead moves the indicator to its pseudo element. This is the implementation used in Unified and supported by FluentUI.

Current | Proposed
---|---
![The Needs review button has a double border on focus](https://user-images.githubusercontent.com/2180540/156372448-b6213430-4bcd-4dcb-84b5-2469a12af590.png) | ![The Needs review button has a single border on focus](https://user-images.githubusercontent.com/2180540/156372614-9c51ef34-4898-4656-bfd6-9ad5ccec57ad.png)



### Remove full-width white background from entire Visual helper toggle

https://github.com/JGibson2019/accessibility-insights-web/commit/68bc710e029f26dedc89e68d3485a460168deeb9 reworks how the `ThemeCustomizer` is applied to elements on the Fast Pass Tab stops page. The `ThemeCustomizer` component provided the initial white background to the toggle, however, too much white background. This fix moves `ThemeCustomizer` to only wrap around the `TabStopsRequirementsTable` (this helps prevent a white background on this section). The result is that the feature branch and prod look the same.

Current | Proposed
---|---
![There is a full-width white background behind the Visual helper toggle.](https://user-images.githubusercontent.com/2180540/156372897-210bd463-d762-423d-a4a0-1a162883690b.png) | ![There is no longer a full-width white background behind the Visual helper toggle and the toggle background is filled in white](https://user-images.githubusercontent.com/2180540/156373028-309bf9cb-48e3-4cd2-85bb-87bc066a0a3c.png)



## Motivation

<!-- This can be as simple as "addresses issue #123" -->

Fixes CSS-related bugs as part of the FluentUI accessibility pass.

## Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

## Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
