### PR TITLE
feat(fluent-ui-release): Address High Contrast Mode A11y Bugs

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -160,6 +160,11 @@
         color: var(--link) !important;
         text-decoration: none;
       }
+      @media screen and (forced-colors: active) {
+        .insights-link {
+          forced-color-adjust: unset;
+        }
+      }
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
@@ -1027,6 +1032,11 @@
       .kebab-menu--eviKu button:hover {
         background-color: var(--menu-item-background-hover);
       }
+      @media screen and (forced-colors: active) {
+        .kebab-menu--eviKu button:hover {
+          background-color: inherit;
+        }
+      }
       .kebab-menu--eviKu button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
@@ -1061,6 +1071,16 @@
       button.kebab-menu-button--dy7Ui:active svg > circle,
       button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
+      }
+      @media screen and (forced-colors: active) {
+        button.kebab-menu-button--dy7Ui:active,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+          color: inherit;
+        }
+        button.kebab-menu-button--dy7Ui:active svg > circle,
+        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+          stroke: inherit;
+        }
       }
       button.kebab-menu-button--dy7Ui > span {
         justify-content: center;

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.scss
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.scss
@@ -10,4 +10,5 @@
     @media screen and (forced-colors: active) {
         color: inherit;
     }
+    @include fluent-forced-color-adjust-override;
 }

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.scss
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.scss
@@ -7,8 +7,17 @@
     font-size: 16px;
     line-height: 24px;
     color: $negative-outcome;
-    @media screen and (forced-colors: active) {
-        color: inherit;
+    &:hover,
+    &:focus {
+        color: LinkText !important;
     }
-    @include fluent-forced-color-adjust-override;
+
+    @media screen and (forced-colors: active) {
+        @include fluent-forced-color-adjust-override;
+        color: inherit !important;
+        &:hover,
+        &:focus {
+            color: initial !important;
+        }
+    }
 }

--- a/src/DetailsView/components/failure-instance-panel.scss
+++ b/src/DetailsView/components/failure-instance-panel.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../common/styles/colors.scss';
+@import '../../common/styles/common.scss';
 
 .failure-instance-panel {
     .observed-failure-textfield {
@@ -55,4 +56,5 @@
     @media screen and (forced-colors: active) {
         color: inherit !important;
     }
+    @include fluent-forced-color-adjust-override;
 }

--- a/src/DetailsView/components/failure-instance-panel.scss
+++ b/src/DetailsView/components/failure-instance-panel.scss
@@ -53,8 +53,17 @@
     font-size: 16px !important;
     line-height: 24px !important;
     color: $neutral-100 !important;
-    @media screen and (forced-colors: active) {
-        color: inherit !important;
+    &:hover,
+    &:focus {
+        color: LinkText !important;
     }
-    @include fluent-forced-color-adjust-override;
+
+    @media screen and (forced-colors: active) {
+        @include fluent-forced-color-adjust-override;
+        color: inherit !important;
+        &:hover,
+        &:focus {
+            color: initial !important;
+        }
+    }
 }

--- a/src/DetailsView/components/nav-link-button.scss
+++ b/src/DetailsView/components/nav-link-button.scss
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common/styles/common.scss';
+
 a,
 button {
     &.nav-link-button {
@@ -9,5 +11,6 @@ button {
         &:active:hover {
             text-decoration: none;
         }
+        @include fluent-forced-color-adjust-override;
     }
 }

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
@@ -18,6 +18,7 @@
     @media screen and (forced-colors: active) {
         color: inherit !important;
     }
+    @include fluent-forced-color-adjust-override;
 }
 
 .remove-button {
@@ -27,4 +28,5 @@
     @media screen and (forced-colors: active) {
         color: inherit;
     }
+    @include fluent-forced-color-adjust-override;
 }

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
@@ -15,18 +15,37 @@
     font-size: 16px !important;
     line-height: 24px !important;
     color: $neutral-100 !important;
-    @media screen and (forced-colors: active) {
-        color: inherit !important;
+
+    &:hover,
+    &:focus {
+        color: LinkText !important;
     }
-    @include fluent-forced-color-adjust-override;
+
+    @media screen and (forced-colors: active) {
+        @include fluent-forced-color-adjust-override;
+        color: inherit !important;
+        &:hover,
+        &:focus {
+            color: initial !important;
+        }
+    }
 }
 
 .remove-button {
     font-size: 16px;
     line-height: 24px;
-    color: $negative-outcome;
-    @media screen and (forced-colors: active) {
-        color: inherit;
+    color: $negative-outcome !important;
+    &:hover,
+    &:focus {
+        color: LinkText !important;
     }
-    @include fluent-forced-color-adjust-override;
+
+    @media screen and (forced-colors: active) {
+        @include fluent-forced-color-adjust-override;
+        color: inherit !important;
+        &:hover,
+        &:focus {
+            color: initial !important;
+        }
+    }
 }

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -10,14 +10,6 @@ div.kebab-menu-callout {
     > div {
         border-radius: 4px;
     }
-
-    button:hover,
-    button:focus {
-        @include fluent-forced-color-adjust-override;
-        @media screen and (forced-colors: active) {
-            color: ActiveText;
-        }
-    }
 }
 
 .kebab-menu {
@@ -32,10 +24,8 @@ div.kebab-menu-callout {
         }
         &:hover {
             background-color: $menu-item-background-hover;
-            i {
-                @media screen and (forced-colors: active) {
-                    color: ActiveText;
-                }
+            @media screen and (forced-colors: active) {
+                background-color: inherit;
             }
         }
         &:active {
@@ -76,9 +66,9 @@ button.kebab-menu-button {
             stroke: $always-black;
         }
         @media screen and (forced-colors: active) {
-            color: ActiveText;
+            color: inherit;
             svg > circle {
-                stroke: ActiveText;
+                stroke: inherit;
             }
         }
     }

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../styles/colors.scss';
+@import '../../styles/common.scss';
 
 div.kebab-menu-callout {
     box-shadow: 0px 6.4px 14.4px $box-shadow-132, 0px 1.2px 3.6px $box-shadow-108;
@@ -8,6 +9,14 @@ div.kebab-menu-callout {
     border-width: 0px;
     > div {
         border-radius: 4px;
+    }
+
+    button:hover,
+    button:focus {
+        @include fluent-forced-color-adjust-override;
+        @media screen and (forced-colors: active) {
+            color: ActiveText;
+        }
     }
 }
 
@@ -23,6 +32,11 @@ div.kebab-menu-callout {
         }
         &:hover {
             background-color: $menu-item-background-hover;
+            i {
+                @media screen and (forced-colors: active) {
+                    color: ActiveText;
+                }
+            }
         }
         &:active {
             background-color: $menu-item-background-active;
@@ -60,6 +74,12 @@ button.kebab-menu-button {
         color: $always-black;
         svg > circle {
             stroke: $always-black;
+        }
+        @media screen and (forced-colors: active) {
+            color: ActiveText;
+            svg > circle {
+                stroke: ActiveText;
+            }
         }
     }
 

--- a/src/common/styles/high-contrast-override.scss
+++ b/src/common/styles/high-contrast-override.scss
@@ -10,6 +10,8 @@
     }
 }
 
+// Fluent sets forced-color-adjust: none on several components,
+// preventing high contrast color application
 @mixin fluent-forced-color-adjust-override {
     @media screen and (forced-colors: active) {
         forced-color-adjust: unset;

--- a/src/common/styles/high-contrast-override.scss
+++ b/src/common/styles/high-contrast-override.scss
@@ -9,3 +9,9 @@
         }
     }
 }
+
+@mixin fluent-forced-color-adjust-override {
+    @media screen and (forced-colors: active) {
+        forced-color-adjust: unset;
+    }
+}

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -43,7 +43,7 @@ button::after {
     // marking important to override office fabric style
     color: $link !important;
     text-decoration: none;
-
+    @include fluent-forced-color-adjust-override;
     &:hover {
         color: $link-hover !important;
         text-decoration: underline;

--- a/src/popup/components/ad-hoc-tools-panel.scss
+++ b/src/popup/components/ad-hoc-tools-panel.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../common/styles/colors.scss';
+@import '../../common/styles/common.scss';
 
 .ad-hoc-tools-panel {
     padding-right: 8px;
@@ -28,6 +29,7 @@
         .link {
             color: $link !important;
             font-size: 11px;
+            @include fluent-forced-color-adjust-override;
         }
 
         .back-to-launch-pad-icon {


### PR DESCRIPTION
#### Details

This PR addresses High Contrast Mode bugs identified in our recent accessibility pass:

- [x] Assessment does not correctly apply contrast colors:
  - [x]  side nav buttons
     ![side nav side-by-side: after on left, before on right](https://user-images.githubusercontent.com/3230904/156457131-9936a5fd-ef32-4ed8-9b53-e70e86b038a8.png)
  - [x] target page link
    ![target link before](https://user-images.githubusercontent.com/3230904/156457336-72b82820-9270-460b-872f-200c0b98d4f5.png)
    ![target link after](https://user-images.githubusercontent.com/3230904/156457484-93e66dd5-4cf9-4b9c-bc81-ddcd8db959d1.png)
  - [x]~~save/load button borders~~ Fluent's colors are fine
  - [x] failure instance edit/delete buttons
    ![edit/remove buttons before](https://user-images.githubusercontent.com/3230904/156457928-ae55d6e4-ea2d-4c1d-b258-138cb13a9d13.png)
    ![edit/remove buttons after](https://user-images.githubusercontent.com/3230904/156457829-525a12b7-a006-48ed-85a6-3789623a6bc5.png)
- [x] ~~Tab stops undo/add instance buttons~~ Fluent's colors are fine
- [x] Launch pad buttons to fastpass/assessment/ad-hoc tools
    ![launch pad before changes](https://user-images.githubusercontent.com/3230904/156456335-d2fe6873-7813-4cbc-8eb6-4d0907cd0040.png)
    ![launch pad after changes](https://user-images.githubusercontent.com/3230904/156456453-7721f428-dc1f-41cb-b1a9-3f8236d1f980.png)
- [x] Adhoc tools back to launch pad link
    ![adhoc tools before](https://user-images.githubusercontent.com/3230904/156456707-255aad21-30bf-4ef7-beaf-552b2bd8a0bf.png)
    ![adhoc tools after](https://user-images.githubusercontent.com/3230904/156456551-8c85b22b-652d-44ac-9f7b-c73970f2c65e.png)

##### Motivation

Feature Work

##### Context

FluentUI treats some controls differently than Fabric used to when in OS-level high contrast mode. We've made the decision to defer to Fluent's treatment of specific colors (e.g. button borders, undo button color are different between this PR and production) but needed to explicitly override `forced-color-adjust: none` in several places to allow colors to be changed for high contrast mode. For this, I created a mixin that can be included in components where overriding is necessary.

This is a similar challenge as is described in discussion about Fluent UI's approach to high contrast in components [here](https://github.com/microsoft/fluentui/issues/19725#issuecomment-949053858).

#### Pull request checklist
- [x] Ran `yarn fastpass`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
